### PR TITLE
chore(OP-2780): pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,8 @@ jobs:
     name: Build and publish to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,9 +15,9 @@ jobs:
         node-version: ["16.x", "20.x"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Set up Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"


### PR DESCRIPTION
## Action required: merge before ~April 20

Platform Engineering is enabling the GitHub org policy **"Require actions to be pinned to a full-length commit SHA"** (week 17). Once active, any workflow that references an action by version tag (e.g. `@v4`) will be **blocked from running**.

This PR pins all actions in this repo to their full commit SHA so workflows keep running after the policy is enforced.

**Please merge this PR before week 17 (April 20).** If you have questions, reach out in [#support-platform-engineering](https://aignostics.slack.com/archives/C06D26P439V) or see [OP-2780](https://aignx.atlassian.net/browse/OP-2780).

[OP-2780]: https://aignx.atlassian.net/browse/OP-2780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ